### PR TITLE
Improve transcript line-breaking algorithm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,7 @@ The skill behaves differently in two environments:
 - Sentence-ending punctuation is now the primary break signal (matching industry best practices)
 - Added paragraph breaks (blank lines) when time gap between lines exceeds 6 seconds
 - Improved false start detection ("One of my One of my" → "One of my")
-- Added `--clean` flag to remove filler words (uh, um) for cleaner LLM consumption
-- SKILL.md now recommends `--timestamps --clean` as the default
+- Filler words (uh, um) are now always removed for cleaner LLM consumption
 
 ### Duration in Metadata (2026-02-01)
 - Added `ZDURATION` to the metadata extraction query
@@ -66,10 +65,7 @@ To test the skill locally:
 # List recent recordings (metadata)
 python3 apple-voice-memos/scripts/extract-apple-voice-memos-metadata "$HOME/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/CloudRecordings.db" -d 30
 
-# Extract transcript from a specific file (recommended - with timestamps and cleaned)
-python3 apple-voice-memos/scripts/extract-apple-voice-memos-transcript "$HOME/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/<FILENAME>.m4a" --timestamps --clean
-
-# Extract transcript with timestamps but keep filler words (uh, um)
+# Extract transcript from a specific file (with timestamps - recommended)
 python3 apple-voice-memos/scripts/extract-apple-voice-memos-transcript "$HOME/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/<FILENAME>.m4a" --timestamps
 
 # Extract transcript without timestamps (text only)

--- a/apple-voice-memos/SKILL.md
+++ b/apple-voice-memos/SKILL.md
@@ -61,9 +61,9 @@ Extracts recording metadata (title, date, duration, filename) from the CloudReco
 
 Extracts the transcript embedded in a Voice Memo `.m4a` file. Apple stores transcripts in a proprietary `tsrp` atom inside the m4a container.
 
-- **IMPORTANT**: Always use `--timestamps --clean` for the best LLM-readable output
+- **IMPORTANT**: Always use `--timestamps` for the best LLM-readable output
 - The `--timestamps` option shows when each segment was spoken in `[M:SS]` or `[H:MM:SS]` format
-- The `--clean` option removes filler words (uh, um) for cleaner output
+- Filler words (uh, um) are automatically removed for cleaner output
 - Output includes paragraph breaks (blank lines) at topic shifts (6+ second pauses)
 - Not all recordings have transcripts; the tool will exit with an error if no `tsrp` atom is found
 - Only Python 3 standard library is required (no dependencies)
@@ -94,7 +94,7 @@ Claude Desktop runs in a Linux container without access to your Mac's filesystem
 
 3. **Extract the transcript**:
    ```bash
-   python3 /mnt/skills/apple-voice-memos/scripts/extract-apple-voice-memos-transcript "/mnt/user-data/uploads/<FILENAME>" --timestamps --clean
+   python3 /mnt/skills/apple-voice-memos/scripts/extract-apple-voice-memos-transcript "/mnt/user-data/uploads/<FILENAME>" --timestamps
    ```
 
 4. **Present the results**:
@@ -136,10 +136,10 @@ Display the recordings in a clear table or list format showing:
 If the user asked for a transcript of a specific memo, or if there is only one result, fetch the transcript:
 
 ```bash
-python3 ~/.claude/skills/apple-voice-memos/scripts/extract-apple-voice-memos-transcript "$HOME/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/<FILENAME>" --timestamps --clean
+python3 ~/.claude/skills/apple-voice-memos/scripts/extract-apple-voice-memos-transcript "$HOME/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/<FILENAME>" --timestamps
 ```
 
-**Note**: Always use `--timestamps --clean` for the best output. The `--timestamps` flag provides temporal context, and `--clean` removes filler words (uh, um) for cleaner LLM consumption. Output includes paragraph breaks (blank lines) at natural topic shifts.
+**Note**: Always use `--timestamps` for the best output. This provides temporal context and automatically removes filler words (uh, um) for cleaner LLM consumption. Output includes paragraph breaks (blank lines) at natural topic shifts.
 
 Example output with timestamps:
 ```

--- a/apple-voice-memos/scripts/extract-apple-voice-memos-transcript
+++ b/apple-voice-memos/scripts/extract-apple-voice-memos-transcript
@@ -127,13 +127,8 @@ def clean_pause_markers(text):
     return text
 
 
-def clean_disfluencies(text, remove_fillers=False):
-    """Clean up common speech disfluencies while preserving meaning.
-
-    Args:
-        text: The text to clean
-        remove_fillers: If True, remove filler words like "uh", "um"
-    """
+def clean_disfluencies(text):
+    """Clean up common speech disfluencies while preserving meaning."""
     # First clean pause markers
     text = clean_pause_markers(text)
 
@@ -155,13 +150,11 @@ def clean_disfluencies(text, remove_fillers=False):
     pattern = r'\b(\w+)\s+\1\b'
     text = re.sub(pattern, r'\1', text, flags=re.IGNORECASE)
 
-    # Remove filler words if requested
-    if remove_fillers:
-        # Remove "uh", "um", "uh...", "um..." including with punctuation
-        text = re.sub(r'\b[Uu]h\.{0,3}\s*', '', text)
-        text = re.sub(r'\b[Uu]m\.{0,3}\s*', '', text)
-        text = re.sub(r',\s*[Uu]h\s*,', ',', text)  # Handle ", uh," patterns
-        text = re.sub(r',\s*[Uu]m\s*,', ',', text)
+    # Remove filler words (uh, um)
+    text = re.sub(r'\b[Uu]h\.{0,3}\s*', '', text)
+    text = re.sub(r'\b[Uu]m\.{0,3}\s*', '', text)
+    text = re.sub(r',\s*[Uu]h\s*,', ',', text)  # Handle ", uh," patterns
+    text = re.sub(r',\s*[Uu]m\s*,', ',', text)
 
     # Clean up spacing around punctuation
     text = re.sub(r'\s+([.,;:!?])', r'\1', text)  # Remove space before punctuation
@@ -176,13 +169,8 @@ def clean_disfluencies(text, remove_fillers=False):
     return text.strip()
 
 
-def extract_text_with_timestamps(json_obj, remove_fillers=False):
-    """Extract text segments with their timestamps from the JSON object.
-
-    Args:
-        json_obj: The parsed JSON transcript data
-        remove_fillers: If True, remove filler words (uh, um) from output
-    """
+def extract_text_with_timestamps(json_obj):
+    """Extract text segments with their timestamps from the JSON object."""
     # Paragraph break threshold (seconds between lines to insert blank line)
     PARAGRAPH_GAP_THRESHOLD = 6.0
 
@@ -259,7 +247,7 @@ def extract_text_with_timestamps(json_obj, remove_fillers=False):
             ):
                 # Clean and add the completed line
                 line_text = ' '.join(current_line_text)
-                line_text = clean_disfluencies(line_text, remove_fillers=remove_fillers)
+                line_text = clean_disfluencies(line_text)
                 if line_text.strip():
                     lines.append((current_line_time, line_text))
                 current_line_time = time
@@ -272,7 +260,7 @@ def extract_text_with_timestamps(json_obj, remove_fillers=False):
     # Add the last line
     if current_line_text:
         line_text = ' '.join(current_line_text)
-        line_text = clean_disfluencies(line_text, remove_fillers=remove_fillers)
+        line_text = clean_disfluencies(line_text)
         if line_text.strip():
             lines.append((current_line_time, line_text))
 
@@ -294,7 +282,7 @@ def extract_text_with_timestamps(json_obj, remove_fillers=False):
     return "\n".join(result)
 
 
-def process_m4a_file(filename, mode, remove_fillers=False):
+def process_m4a_file(filename, mode):
     with open(filename, "rb") as f:
         file_size = f.seek(0, 2)
         f.seek(0)
@@ -335,7 +323,7 @@ def process_m4a_file(filename, mode, remove_fillers=False):
             return
 
         if mode == "timestamps":
-            result = extract_text_with_timestamps(json_obj, remove_fillers=remove_fillers)
+            result = extract_text_with_timestamps(json_obj)
             if result:
                 print(result)
             return
@@ -372,10 +360,6 @@ if __name__ == "__main__":
     group.add_argument(
         "--timestamps", action="store_true", help="print transcript with timestamps"
     )
-    parser.add_argument(
-        "--clean", action="store_true",
-        help="remove filler words (uh, um) from output (use with --timestamps)"
-    )
     args = parser.parse_args()
 
     if args.json:
@@ -387,4 +371,4 @@ if __name__ == "__main__":
     else:
         mode = "text"
 
-    process_m4a_file(args.filename, mode=mode, remove_fillers=args.clean)
+    process_m4a_file(args.filename, mode=mode)


### PR DESCRIPTION
- Clean Apple pause markers (ellipsis artifacts like `. ..`) from output
- Make sentence-ending punctuation the primary break signal
- Add paragraph breaks (blank lines) when time gap exceeds 6 seconds
- Improve false start detection ("One of my One of my" → "One of my")
- Remove filler words (uh, um) for LLM consumption